### PR TITLE
style: Button 컴포넌트 스타일링 및 코드 수정

### DIFF
--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -1,0 +1,20 @@
+interface propsType {
+  buttonContent: string;
+  isActive: boolean;
+  btnSize: string;
+  buttonColor: string;
+  onClick: () => void;
+}
+const Button = ({ onClick, buttonContent, isActive = true }: propsType) => {
+  return (
+    <button
+      disabled={!isActive}
+      className={`inline-block w-full rounded-full ${isActive ? 'bg-mainblue' : 'bg-gray-200'} px-3 py-2.5 text-button text-white hover:bg-maingreen hover:text-mainblue`}
+      onClick={onClick}
+    >
+      {buttonContent}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/Buttons/Button.tsx
+++ b/src/components/Buttons/Button.tsx
@@ -1,8 +1,6 @@
 interface propsType {
   buttonContent: string;
   isActive: boolean;
-  btnSize: string;
-  buttonColor: string;
   onClick: () => void;
 }
 const Button = ({ onClick, buttonContent, isActive = true }: propsType) => {

--- a/src/components/Buttons/SelectCountryButton.tsx
+++ b/src/components/Buttons/SelectCountryButton.tsx
@@ -19,6 +19,8 @@ const SelectCountryButton = ({
     navigate(`/${pageUrl}`);
   };
 
+  // imgAlt 를 상위 컴포넌트에서 전달받을지 파일명을 잘라서 사용할지 고민.
+  // 파일명에서 잘라쓰는 로직
   // const imgAlt = (imgSrc: string): string => {
   //   const fileName = imgSrc.split('.')[0];
   //   return fileName;

--- a/src/components/Buttons/SelectCountryButton.tsx
+++ b/src/components/Buttons/SelectCountryButton.tsx
@@ -1,0 +1,41 @@
+interface propsType {
+  buttonContent: string;
+  imgSrc: string;
+  imgAlt: string;
+  pageUrl: string;
+}
+
+import { useNavigate } from 'react-router-dom';
+
+const SelectCountryButton = ({
+  imgSrc = 'shipmatelogo.png',
+  imgAlt,
+  buttonContent,
+  pageUrl,
+}: propsType) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/${pageUrl}`);
+  };
+
+  // const imgAlt = (imgSrc: string): string => {
+  //   const fileName = imgSrc.split('.')[0];
+  //   return fileName;
+  // };
+
+  return (
+    <button
+      className={`inline-block w-40 rounded-full bg-white p-3 text-start text-button text-black shadow-shadow-blue hover:bg-mainblue hover:text-white`}
+      onClick={handleClick}
+    >
+      <img
+        className="inline-block w-8"
+        src={`/assets/${imgSrc}`}
+        alt={`${imgAlt} 선택 버튼 아이콘`}
+      />
+      {buttonContent}
+    </button>
+  );
+};
+export default SelectCountryButton;


### PR DESCRIPTION
## PR 유형

- [ ] 🎉 **init**: 초기 설정
- [ ] 🎨 **feat**: 새로운 기능 추가
- [x] 🔍 **modi** : 코드 수정
- [ ] 🎞 **src**: 이미지, 아이콘 등 소스파일 추가 및 수정
- [ ] 🐛 **fix**: 버그, 오류 수정
- [ ] 📝 **docs**: README.md, JSON 파일 등 문서 수정, 라이브러리 설치 (문서 관련, 코드 수정 없음)
- [x] 💄 **style**: CSS 등 사용자 UI 디자인 변경 (코드 수정 포함, 코드 형식, 정렬, 주석 등의 변경)
- [ ] ♻️ **refactor**: 코드 리팩토링 (기능 변화 없음)
- [ ] 🧪 **test**: 테스트 코드 추가, 삭제, 변경 (코드 수정 없음, 테스트 코드 관련 모든 변경에 해당)
- [ ] 🐎 **ci**: CI 관련 설정 (npm 모듈 설치 등)
- [ ] 🐳 **chore**: 빌드 시스템 또는 패키지 매니저 설정 수정

---

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 완료했습니다. (버그 수정/기능 테스트).

---

### PR 상세
button 스타일링 및 클릭 이벤트를 수정하였습니다.
기본 버튼과 국가 선택 버튼으로 나눴습니다.

- 기본 버튼
![image](https://github.com/user-attachments/assets/3a26c8a9-c7e9-4699-bd4e-f183e806c9d1)
세가지의 props를 전달 받습니다. 버튼 내부의 텍스트, 클릭시 발생할 함수, 그리고 form에 submit 버튼으로 사용시 active한 상태임을 구분하기 위해 isActive 상태를 받는데, 기본값을 true로 지정해 놨습니다.

- 국가 선택 버튼
![image](https://github.com/user-attachments/assets/6ae33df0-63f6-46be-988f-34405555c862)
네가지의 props를 전달받습니다.
버튼 내부의 텍스트와 국가 이미지 src, 국가 이미지 alt, 클릭시 이동할 페이지 url 입니다.
국가 이미지 alt 는 src의 파일명에서 잘라 쓸 수도 있을 것 같아서 함수를 만들어서 주석처리 해뒀습니다. 사용시에는 alt props 를 제거하고 주석처리한 함수를 주석해제 하면 됩니다.
페이지 url은 국가 선택 버튼은 국가 선택시에만 사용되는 버튼이라고 판단하여 버튼 컴포넌트 자체에서 클릭이벤트를 발생하게 하였습니다. 그래서 전달받은 pageurl에 따라서 페이지를 이동하게 하였습니다.


---

## 이슈

`resolves #58 `
